### PR TITLE
update mapbox using modern API

### DIFF
--- a/search_script.js
+++ b/search_script.js
@@ -336,12 +336,27 @@ function initMap() {
   return mymap;
 }
 
+/*
 function initTitleLayer() {
   return L.tileLayer(
     "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}",
     {
       maxZoom: 18,
       id: "mapbox.streets",
+      accessToken: mapbox_public_key
+    }
+  );
+}*/
+
+
+function initTitleLayer() {
+  return L.tileLayer(
+    'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', 
+    {
+      tileSize: 512,
+      maxZoom: 18,
+      zoomOffset: -1,
+      id: 'mapbox/streets-v11',
       accessToken: mapbox_public_key
     }
   );

--- a/search_script_sp.js
+++ b/search_script_sp.js
@@ -336,12 +336,27 @@ function initMap() {
   return mymap;
 }
 
+/*
 function initTitleLayer() {
   return L.tileLayer(
     "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}",
     {
       maxZoom: 18,
       id: "mapbox.streets",
+      accessToken: mapbox_public_key
+    }
+  );
+}*/
+
+
+function initTitleLayer() {
+  return L.tileLayer(
+    'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', 
+    {
+      tileSize: 512,
+      maxZoom: 18,
+      zoomOffset: -1,
+      id: 'mapbox/streets-v11',
       accessToken: mapbox_public_key
     }
   );


### PR DESCRIPTION
Migrating to the modern Static Tiles API
https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/?/=blog&utm_source=mapbox-blog&utm_campaign=blog%7Cmapbox-blog%7Cdoc-migrate-static%7Cdeprecating-studio-classic-styles-d8892ac38cb4-20-03&utm_term=doc-migrate-static&utm_content=deprecating-studio-classic-styles-d8892ac38cb4